### PR TITLE
housekeeping: add OpenAPI document and tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,14 @@
         "negotiator": "0.6.2"
       }
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -132,6 +140,11 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -227,6 +240,15 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
     },
     "kareem": {
       "version": "2.3.0",
@@ -553,10 +575,28 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "swagger-ui-dist": {
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.23.1.tgz",
+      "integrity": "sha512-chMAB3JY3tJGLtswyBJGWa5L0nghbImUtFpy2CupswVVC1UsSmVwOI69oOQ1sCxEzQfC2DCu0jUD/x5SjNs+zw=="
+    },
+    "swagger-ui-express": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.0.7.tgz",
+      "integrity": "sha512-ipXe53qDMjB2GlFcWARof15fMxX0n0wkwUturBpdovfJLaqod3WAqimwQGFXjwpWKA6hnxEPrd31yOzaYkP++A==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
+      }
     },
     "toidentifier": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,12 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
+    },
     "content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
@@ -430,15 +436,37 @@
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "dev": true
     },
+    "open": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
+      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
+      "dev": true
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "dev": true,
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.5",
@@ -585,6 +613,25 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "swagger-editor-dist": {
+      "version": "3.6.31",
+      "resolved": "https://registry.npmjs.org/swagger-editor-dist/-/swagger-editor-dist-3.6.31.tgz",
+      "integrity": "sha512-mX7o2zWq8Fi2wRbYLJc46dWBBGtEwSyNmn26ohfc0tw+A6B7nX/oEwxYaGtoOLyc05jxg+LQMoOWRi5edbQ/1A==",
+      "dev": true
+    },
+    "swagger-editor-live": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/swagger-editor-live/-/swagger-editor-live-2.1.8.tgz",
+      "integrity": "sha1-IwwzrP1Jw53NjwDH8uM5PfGag+Q=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.9.0",
+        "express": "^4.15.3",
+        "open": "0.0.5",
+        "path": "^0.12.7",
+        "swagger-editor-dist": "^3.0.14"
+      }
+    },
     "swagger-ui-dist": {
       "version": "3.23.1",
       "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.23.1.tgz",
@@ -616,6 +663,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "js-yaml": "^3.13.1",
     "mongodb": "^3.3.0-beta2",
-    "mongoose": "^5.6.7"
+    "mongoose": "^5.6.7",
+    "swagger-ui-express": "^4.0.7"
   },
   "devDependencies": {
     "morgan": "^1.9.1"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "This is the api for the hrxp slack archive",
   "main": "server/index.js",
   "scripts": {
+    "openapi:edit": "swagger-editor-live server/openapi.yaml",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "nodemon server/index.js"
   },
@@ -26,6 +27,7 @@
     "swagger-ui-express": "^4.0.7"
   },
   "devDependencies": {
-    "morgan": "^1.9.1"
+    "morgan": "^1.9.1",
+    "swagger-editor-live": "^2.1.8"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,12 @@
 const db = require('../db/index');
+const fs = require('fs');
+const path = require('path');
 const express = require('express');
 const morgan = require('morgan');
 const cors = require('cors');
+const YAML = require("js-yaml")
+const swaggerUi = require('swagger-ui-express');
+
 const app = express();
 // Channel router
 const channel = require('./controller/channel.js');
@@ -15,6 +20,17 @@ app.use(cors());
 app.get('/', (req, res) => {
   res.send('example endpoint');
 });
+
+// OpenAPI documentation
+app.use('/docs', swaggerUi.serve);
+app.get('/docs', swaggerUi.setup(
+  YAML.safeLoad(
+    fs.readFileSync(
+      path.join(__dirname, './openapi.yaml'), 
+      "utf8"
+    )
+  )
+));
 
 // Routes
 app.use('/channels', channel);

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -97,6 +97,8 @@ components:
                 $ref: "#/components/schemas/User"
               ts:
                 $ref: "#/components/schemas/__Timestamp"
+              text:
+                type: string
         createdBy:
           $ref: "#/components/schemas/User"
     User:

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -1,0 +1,167 @@
+openapi: "3.0.0"
+
+info:
+  version: 0.0.3
+  title: HRXP Archive API
+
+tags:
+- name: Channels
+- name: Messages
+
+paths:
+  /channels:
+    get:
+      tags: [Channels]
+      summary: Returns a list of all channels
+      responses:
+        200:
+          description: OK; data in response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Channel'
+  /channels/{channelId}:
+    parameters:
+    - $ref: "#/components/parameters/channelId"
+    get:
+      tags: [Channels]
+      summary: Return a specific channel
+      responses:
+        200:
+          description: OK; data in response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+  /channels/{channelId}/messages:
+    parameters:
+    - $ref: "#/components/parameters/channelId"
+    get:
+      tags: [Channels]
+      summary: Return a specific channel's messages
+      responses:
+        200:
+          description: OK; data in response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Message'
+  /channels/{channelId}/messages/{messageId}:
+    parameters:
+    - $ref: "#/components/parameters/channelId"
+    - $ref: "#/components/parameters/messageId"
+    get:
+      tags: [Channels]
+      summary: Return a specific channel's messages
+      responses:
+        200:
+          description: OK; data in response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Message'
+components:
+  schemas:
+    Channel:
+      type: object
+      properties:
+        id: 
+          type: string
+          example: C035Z8YT7
+        topic:
+          type: string
+          example: Mission 1st, People Always.
+        purpose:
+          type: string
+          example: This channel is for alumni of all Hack Reactor campuses.
+        members:
+          type: array
+          items:
+            $ref: "#/components/schemas/User/properties/id"
+        isArchived:
+          type: boolean
+          default: false
+    Message:
+      type: object
+      properties:
+        id: 
+          type: string
+          example: a55dd3e2-1b1c-4ee8-a05e-9a35dda5710a
+        ts:
+          $ref: "#/components/schemas/__Timestamp"
+        text:
+          type: string
+          example: Happy Monday, everyone!
+        files:
+          type: array
+          items:
+            type: object
+            properties:
+              id: 
+                type: string
+                example: FJ0UW704E
+              displayName:
+                type: string
+                example: contractor-description.pdf
+              fileType:
+                type: string
+                example: pdf
+              downloadUrl:
+                type: string
+                format: url
+                example: "https://hrxp.com/static/files/FJ0UW704E/contractor-description.pdf"
+        replies:
+          type: array
+          items:
+            properties:
+              id: 
+                type: string
+                example: a55dd3e2-1b1c-4ee8-a05e-9a35dda5710b
+              createdBy: 
+                $ref: "#/components/schemas/User"
+              ts:
+                $ref: "#/components/schemas/__Timestamp"
+        createdBy:
+          $ref: "#/components/schemas/User"
+    User:
+      type: object
+      properties:
+        id: 
+          type: string
+          example: U07AT4FB4
+        profilePhoto:
+          type: string
+          example: "https://hrxp.com/static/avatars/U07AT4FB4.png"
+        displayName:
+          type: string
+          example: "Kyle Shockey [HR26]"
+        realName:
+          type: string
+          example: Kyle Shockey
+
+    # UTILITY SCHEMAS, which are just broken out for reusability
+
+    __Timestamp:
+      type: string
+      example: "1501536037.682405"
+      
+
+  parameters:
+    channelId:
+      name: channelId
+      in: path
+      required: true
+      schema:
+        $ref: "#/components/schemas/Channel/properties/id"
+    messageId:
+      name: messageId
+      in: path
+      required: true
+      schema:
+        $ref: "#/components/schemas/Message/properties/id"

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -6,7 +6,6 @@ info:
 
 tags:
 - name: Channels
-- name: Messages
 
 paths:
   /channels:
@@ -22,19 +21,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Channel'
-  /channels/{channelId}:
-    parameters:
-    - $ref: "#/components/parameters/channelId"
-    get:
-      tags: [Channels]
-      summary: Return a specific channel
-      responses:
-        200:
-          description: OK; data in response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Channel'
   /channels/{channelId}/messages:
     parameters:
     - $ref: "#/components/parameters/channelId"

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -50,22 +50,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Message'
-  /channels/{channelId}/messages/{messageId}:
-    parameters:
-    - $ref: "#/components/parameters/channelId"
-    - $ref: "#/components/parameters/messageId"
-    get:
-      tags: [Channels]
-      summary: Return a specific channel's messages
-      responses:
-        200:
-          description: OK; data in response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Message'
 components:
   schemas:
     Channel:
@@ -150,7 +134,6 @@ components:
     __Timestamp:
       type: string
       example: "1501536037.682405"
-      
 
   parameters:
     channelId:
@@ -159,9 +142,3 @@ components:
       required: true
       schema:
         $ref: "#/components/schemas/Channel/properties/id"
-    messageId:
-      name: messageId
-      in: path
-      required: true
-      schema:
-        $ref: "#/components/schemas/Message/properties/id"


### PR DESCRIPTION
This PR:

* adds a `/docs` route to the API, which renders our OpenAPI document with Swagger UI
* adds an `openapi:edit` npm script, which launches Swagger Editor locally and syncs changes back to the filesystem
* introduces an initial OpenAPI document for the API