### PR TITLE
enforce uniqueness of schema `id` fields

### DIFF
--- a/db/model/channel.js
+++ b/db/model/channel.js
@@ -21,10 +21,10 @@ const messageSchema = new mongoose.Schema({
   ts: String,
   text: String,
   channelId: String,
-  files: [{ id: String, displayName: String, fileType: String, downLoadUrl: String }],
+  files: [{ id: { type: String, unique: true }, displayName: String, fileType: String, downLoadUrl: String }],
   replies: [
     {
-      id: String,
+      id: { type: String, unique: true },
       createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
       ts: String,
       text: String,

--- a/db/model/channel.js
+++ b/db/model/channel.js
@@ -9,7 +9,7 @@
 const mongoose = require('mongoose');
 
 const channelSchema = new mongoose.Schema({
-  id: String,
+  id: { type: String, unique: true },
   topic: String,
   purpose: { type: String, unique: true, required: true },
   memebers: [String],
@@ -17,7 +17,7 @@ const channelSchema = new mongoose.Schema({
 });
 
 const messageSchema = new mongoose.Schema({
-  id: String,
+  id: { type: String, unique: true },
   ts: String,
   text: String,
   channelId: String,
@@ -34,7 +34,7 @@ const messageSchema = new mongoose.Schema({
 });
 
 const userSchema = new mongoose.Schema({
-  id: String,
+  id: { type: String, unique: true },
   profilePhoto: String,
   displayName: String,
   realName: String,


### PR DESCRIPTION
This should keep us from making a mess of our collections, since we're planning to keep track of what we do and don't already have in the DB based on Slack's IDs.