### PR TITLE
chore: Heroku compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MONGO_URL=mongodb://localhost:27017/hrxp-dev

--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ API and backend for the HRX Project.
 
 ## Getting Started
 
-
-- Run `npm i` from the command line
-- Navigate to `db/config.example.js` and rename to `db/config.js`
-- Insert the MongoURL into the appropiate spot
-- Run `npm start`
+- Run `npm i`
+- Run `cp .env.example .env`, then open `.env` and edit the values if needed
+- Run `npm run dev`
 
 ## API documentation
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ API and backend for the HRX Project.
 - Run `cp .env.example .env`, then open `.env` and edit the values if needed
 - Run `npm run dev`
 
+## Environment variables
+
+| Name        | Description                   | Required? | Default     |
+|-------------|-------------------------------|-----------|-------------|
+| `MONGO_URL` | The MongoDB URL to use        | **Yes**   | _undefined_ |
+| `PORT`      | The port to expose the API on | No        | `3000`      |
+
 ## API documentation
 
 The API is documented in [`server/openapi.yaml`](https://github.com/hrxp/api/blob/master/server/openapi.yaml). 

--- a/db/config.example.js
+++ b/db/config.example.js
@@ -1,3 +1,0 @@
-module.exports = {
-  mongoURL: 'insert url here',
-};

--- a/db/index.js
+++ b/db/index.js
@@ -1,7 +1,6 @@
 const mongoose = require('mongoose');
-const { mongoURL } = require('./config');
 
-const db = mongoose.connect(mongoURL, { useNewUrlParser: true, useCreateIndex: true });
+const db = mongoose.connect(process.env.MONGO_URL, { useNewUrlParser: true, useCreateIndex: true });
 
 db.then(() => console.log(`Connected to: hrxp-api-database`)).catch(err => {
   console.log(`There was a problem connecting to mongo at: ${mongoURL}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -391,6 +391,12 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
+    "dotenv": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
+      "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==",
+      "dev": true
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
+    "dotenv": "^8.0.0",
     "faker": "^4.1.0",
     "mocha": "^6.2.0",
     "morgan": "^1.9.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,6 @@
+// load `.env` config values into `process.env`
+require('dotenv').config();
+
 const db = require('../db/index');
 const fs = require('fs');
 const path = require('path');

--- a/server/index.js
+++ b/server/index.js
@@ -42,9 +42,11 @@ app.get('/docs', swaggerUi.setup(
 // Routes
 app.use('/channels', channel);
 
-const server = app.listen(3000, () => {
+const PORT = process.env.PORT || 3000;
+
+const server = app.listen(PORT, () => {
   if (process.env.NODE_ENV !== 'test') {
-    console.log('Hido ho, Captn! Listening on port 3000.');
+    console.log(`Hido ho, Captn! Listening on port ${PORT}.`);
   }
 });
 


### PR DESCRIPTION
This PR replaces the old config system with a [`dotenv`](https://npmjs.com/package/dotenv) config loader, which lets us set configuration values with environment variables.

It also adds a PORT env var, which allows us to override the default port 3000.