### PR TITLE
chore: add dev/prod npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ API and backend for the HRX Project.
 
 ## Getting Started
 
-
 - Run `npm i` from the command line
 - Navigate to `db/config.example.js` and rename to `db/config.js`
 - Insert the MongoURL into the appropiate spot
-- Run `npm start`
+- Run `npm run dev`
 
 ## API documentation
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha ./server/controller/tests/channels.test.js --timeout 10000 --watch",
     "openapi:edit": "swagger-editor-live server/openapi.yaml",
     "dev": "nodemon server/index.js",
-    "start": "node server/index.js"
+    "start": "NODE_ENV=production node server/index.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "mocha ./server/controller/tests/channels.test.js --timeout 10000 --watch",
     "openapi:edit": "swagger-editor-live server/openapi.yaml",
-    "start": "nodemon server/index.js"
+    "dev": "nodemon server/index.js",
+    "start": "node server/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR:
* rewires `npm start` to run a production-mode instance of the API
* adds a `dev` script for use in development