### PR TITLE
improve: exit app when DB can't connect

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -6,6 +6,7 @@ const db = mongoose.connect(mongoURL, { useNewUrlParser: true, useCreateIndex: t
 db.then(() => console.log(`Connected to: hrxp-api-database`)).catch(err => {
   console.log(`There was a problem connecting to mongo at: ${mongoURL}`);
   console.log(err);
+  process.exit(1);
 });
 
 module.exports = db;


### PR DESCRIPTION
Improves our ability to detect problems connecting to the DB when we're deploying -- specifically, Heroku assumes a process is healthy unless it exits with a non-zero code.